### PR TITLE
Direct repos for SqueezeCloud and MixCloud plugins

### DIFF
--- a/include.json
+++ b/include.json
@@ -7,6 +7,8 @@
 		"http://mjohnen.bplaced.net/repo/repo.xml",
 		"http://pluginrepository.penguinlovesmusic.de/pluginrepo.xml",
 		"http://ralph.irving.sdf.org/edo/edo-repo.xml",
+		"https://danielvijge.github.io/SqueezeCloud/public.xml",
+		"https://danielvijge.github.io/lms_mixcloud/public.xml",
 		"http://server.vijge.net/static/squeezebox/repo.xml",
 		"http://slimscrobbler.sourceforge.net/repository.xml",
 		"http://superdatetimewu.sourceforge.net/CC_JL_repo.xml",


### PR DESCRIPTION
Use the direct repository files from Github for the SqueezeCloud (Soundcloud) and MixCloud plugins.

There are also included in my personal repository (http://server.vijge.net/static/squeezebox/repo.xml). I have a script there that pulls them in from Github and adds them to one feed. With this pull request this is no longer needed, and simplifies the setup.

(also, the repo is hosted on OVH Strasbourg, which is currently offline due to a large fire. No idea if/when I can be back online)