### PR TITLE
Update include.json to include pyrrha

### DIFF
--- a/include.json
+++ b/include.json
@@ -46,7 +46,8 @@
 		"https://mspertus.github.io/lms-downloads/repo.xml",
 		"http://www.hashsum.org/LMS/repo.xml",
 		"https://tvh.codechimp.org/repo.xml",
-		"https://raw.githubusercontent.com/michaelherger/lms-plugin-tidal/main/repo/repo.xml"
+		"https://raw.githubusercontent.com/michaelherger/lms-plugin-tidal/main/repo/repo.xml",
+		"https://github.com/sspiff/lms-plugin-pyrrha/releases/download/repo-stable/repo.xml"
 	],
 	"disabled": [
 		"https://grebrown-projects.googlecode.com/svn/repo.xml",


### PR DESCRIPTION
This is the local plugin to replace Pandora on mysb. repo XML includes a "category" field ... so, in theory, it should not require explicit mapping in the updater script. Something to check on first run. See https://forums.slimdevices.com/forum/user-forums/3rd-party-software/1675996-pyrrha-pandora-s-daughter?view=thread and post there from today by author asking to be added here.