### PR TITLE
Add Repackaged/Renamed CustomClock for Jivelite.

### DIFF
--- a/include.json
+++ b/include.json
@@ -12,7 +12,7 @@
 		"https://danielvijge.github.io/lms_mixcloud/public.xml",
 		"https://server.vijge.net/static/squeezebox/repo.xml",
 		"https://slimscrobbler.sourceforge.net/repository.xml",
-		"https://superdatetimewu.sourceforge.net/CC_JL_repo.xml",
+		"http://jivelite.picoreplayer.org/repo.xml"
 		"http://radionowplaying.com/slimserver-rep/repo.xml",
 		"https://www.erspearson.com/xAP/Slim/Updates.xml",
 		"https://www.gwendesign.com/sc/repo/repo.xml",


### PR DESCRIPTION
Remove the old CustomClock for jivelite link.  It would not work anyway since CustomClock from erland was a newer version.

This package allows users to install customclock for jivelite via the jivelite applet installer.