### PR TITLE
Add Radio Helsinki plugin repository

### DIFF
--- a/include.json
+++ b/include.json
@@ -48,6 +48,7 @@
 		"https://raw.githubusercontent.com/nbeversl/lyrion-repo/refs/heads/main/repo.xml",
 		"https://raw.githubusercontent.com/onmomo/lms-squeeze-plex-hub/refs/heads/develop/repo/repo.xml",
 		"https://raw.githubusercontent.com/open-horizon-labs/unified-hifi-control/v3/lms-plugin/repo.xml",
+		"https://raw.githubusercontent.com/patapovich/rh-ondemand-lyrion/main/repo.xml",
 		"https://raw.githubusercontent.com/philippe44/lms-deezer/main/repo/repo.xml",
 		"https://raw.githubusercontent.com/phkehl/lms-plugins/main/repo.xml",
 		"https://raw.githubusercontent.com/ralph-irving/plugin-CommunityFirmware/main/repo.xml",


### PR DESCRIPTION
Adds the Radio Helsinki on-demand plugin repository to the list.

- Plugin: browse and play Radio Helsinki (Finnish community radio) on-demand programs, podcasts and clips
- Source: https://github.com/patapovich/rh-ondemand-lyrion
- repo.xml: https://raw.githubusercontent.com/patapovich/rh-ondemand-lyrion/main/repo.xml
- Zip is distributed as a GitHub release asset; SHA in repo.xml verified against the asset.